### PR TITLE
Proposed addition to support S3 read streaming

### DIFF
--- a/src/AwsS3.php
+++ b/src/AwsS3.php
@@ -3,6 +3,7 @@
 namespace devtoolboxuk\aws;
 
 use \Aws\S3\S3Client;
+use Aws\S3\StreamWrapper;
 
 class AwsS3
 {
@@ -128,6 +129,20 @@ class AwsS3
         } catch (S3Exception $e) {
             throw new \S3Exception(sprintf("Failed to read file '%s' from S3.", $s3filename));
         }
+    }
+
+    /**
+     * Gets a stream wrapper to load data in chunks
+     *
+     * The docs in the Aws\S3\StreamWrapper class are well worth a look.
+     *
+     * @return StreamWrapper
+     */
+    public function getStreamWrapper()
+    {
+        StreamWrapper::register($this->s3Client);
+
+        return new StreamWrapper();
     }
 
     public function listObjects($folder)


### PR DESCRIPTION
I have got S3 streaming working, which will be nice to handle large files. My demo code looks like this:

    $stream = $aws->getStreamWrapper();
    $openedPath = null;
    $stream->stream_open("s3://{$bucketName}/{$objectName}", 'r', null, $openedPath);
    $chunkCount = 0;
    while (!$stream->stream_eof())
    {
        // Read in 10K chunks
        $chunk = $stream->stream_read(100 * 1024);
        $chunkCount++;
    }
    echo sprintf(
        "Using a stream, there were %d chunks\n",
        $chunkCount
    );

    // Always tidy up after yourself
    $stream->stream_close();

To get that working, I have manually added a new method, to create a stream object. What do you reckon?

If that looks OK, would you merge and push a new tag?
